### PR TITLE
Feature/enudet corsika

### DIFF
--- a/G4SOLAr/CMakeLists.txt
+++ b/G4SOLAr/CMakeLists.txt
@@ -121,6 +121,14 @@ find_library(MARLEY_ROOT
   NO_DEFAULT_PATH
   )
 
+if (NOT ECosmic_DIR)
+  set(ECosmic_DIR "${G4SOLAR_EXT_DIR}/ENUBETCosmics")
+endif()
+find_package(ECosmic REQUIRED PATHS ${ECosmic_DIR} NO_DEFAULT_PATH)
+if (ECosmic_FOUND)
+  message(STATUS "ECosmic found: include at ${ECosmic_INCLUDE_DIR}")
+endif()
+
 #----------------------------------------------------------------------------
 # Locate sources and headers for this project
 #
@@ -136,6 +144,7 @@ include_directories(${G4SOLAR_INCLUDE_DIR}
                     ${G4SOLAR_INCLUDE_DIR}/physics
                     ${BxDecay0_INCLUDE_DIR}
                     ${MARLEY_DIR}/include
+                    ${ECosmic_INCLUDE_DIR}
                     ${RapidJSON_INCLUDE_DIR}/..
                     ${Geant4_INCLUDE_DIR}
                     ${ROOT_INCLUDE_DIRS}

--- a/G4SOLAr/extern/CMakeLists.txt
+++ b/G4SOLAr/extern/CMakeLists.txt
@@ -58,3 +58,15 @@ ExternalProject_Add("marley"
   INSTALL_COMMAND cmake -E echo "MARLEY: Skipping install step"
   )
 
+ExternalProject_add("ENUBETCosmics"
+  SOURCE_DIR ${PROJECT_SOURCE_DIR}/src/ENUBETCosmics
+  BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/ENUBETCosmics-build
+  INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/ENUBETCosmics
+  UPDATE_DISCONNECTED 0
+  GIT_REPOSITORY "https://github.com/dguff/ENUBETCosmics.git"
+  GIT_TAG "feature/cmake-compile"
+  CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}/ENUBETCosmics
+  BUILD_COMMAND cmake --build . -j 4
+  INSTALL_COMMAND cmake --install .
+  )
+

--- a/G4SOLAr/extern/CMakeLists.txt
+++ b/G4SOLAr/extern/CMakeLists.txt
@@ -58,15 +58,15 @@ ExternalProject_Add("marley"
   INSTALL_COMMAND cmake -E echo "MARLEY: Skipping install step"
   )
 
-ExternalProject_add("ENUBETCosmics"
-  SOURCE_DIR ${PROJECT_SOURCE_DIR}/src/ENUBETCosmics
-  BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/ENUBETCosmics-build
-  INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/ENUBETCosmics
+ExternalProject_add("ecosmics"
+  SOURCE_DIR ${PROJECT_SOURCE_DIR}/src/ecosmics
+  BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/ecosmics-build
+  INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/ecosmics
   UPDATE_DISCONNECTED 0
-  GIT_REPOSITORY "https://github.com/dguff/ENUBETCosmics.git"
-  GIT_TAG "feature/cmake-compile"
-  CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}/ENUBETCosmics
-  BUILD_COMMAND cmake --build . -j 4
+  GIT_REPOSITORY "https://github.com/JMMcElwee/ENUBETCosmics"
+  GIT_TAG "main"
+  CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}/ecosmics
+  BUILD_COMMAND cmake --build . -j 6
   INSTALL_COMMAND cmake --install .
   )
 


### PR DESCRIPTION
Include ECosmic into the automatic building of the external dependencies. Requires no additional steps in the building, and should be automatic.