### PR TITLE
Fix compile warnings for CXX 17

### DIFF
--- a/G4SOLAr/include/SLArVertextGenerator.hh
+++ b/G4SOLAr/include/SLArVertextGenerator.hh
@@ -93,7 +93,7 @@ namespace gen {
           d.SetObject(); 
           std::string mode_str = GetTimeGeneratorModeString(fConfig.mode).data();
           char buffer[50]; 
-          int len = sprintf(buffer, "%s", mode_str.data());
+          int len = snprintf(buffer, sizeof(buffer), "%s", mode_str.data());
           rapidjson::Value jmode;
           jmode.SetString(buffer, len, d.GetAllocator());
           d.AddMember("mode", jmode, d.GetAllocator());
@@ -244,7 +244,7 @@ namespace gen {
 
         G4String gen_type = GetType();
         char buffer[50];
-        int len = sprintf(buffer, "%s", gen_type.data());
+        int len = snprintf(buffer, sizeof(buffer), "%s", gen_type.data());
         rapidjson::Value str_gen_type;
         str_gen_type.SetString(buffer, len, vtx_info.GetAllocator());
 

--- a/G4SOLAr/src/SLArBaseGenerator.cc
+++ b/G4SOLAr/src/SLArBaseGenerator.cc
@@ -29,18 +29,18 @@ const rapidjson::Document SLArBaseGenerator::ExtSourceInfo_t::ExportConfig() con
   hist_doc.SetObject(); 
 
   char buffer[200];
-  int len = sprintf(buffer, "%s", filename.data());
+  int len = snprintf(buffer, sizeof(buffer), "%s", filename.data());
   rapidjson::Value jfilename;
   jfilename.SetString(buffer, len, hist_doc.GetAllocator());
   hist_doc.AddMember("filename", jfilename, hist_doc.GetAllocator()); 
 
   rapidjson::Value jobjname(rapidjson::kStringType);
-  len = sprintf(buffer, "%s", objname.data()); 
+  len = snprintf(buffer, sizeof(buffer), "%s", objname.data()); 
   jobjname.SetString(buffer, len, hist_doc.GetAllocator()); 
   hist_doc.AddMember("objname", jobjname, hist_doc.GetAllocator()); 
 
   rapidjson::Value jtype(rapidjson::kStringType);
-  len = sprintf(buffer, "%s", type.data()); 
+  len = snprintf(buffer, sizeof(buffer), "%s", type.data()); 
   jtype.SetString(buffer, len, hist_doc.GetAllocator()); 
   hist_doc.AddMember("type", jtype, hist_doc.GetAllocator()); 
   return hist_doc; 
@@ -109,7 +109,7 @@ void SLArBaseGenerator::SetupVertexGenerator(const rapidjson::Value& config) {
       {
         char err_msg[100];
         gen::printVtxGeneratorType();
-        sprintf(err_msg, "Unable to find %s vertex generator among the available options\n", 
+        snprintf(err_msg, sizeof(err_msg), "Unable to find %s vertex generator among the available options\n", 
             type.data()); 
         std::cerr << err_msg << std::endl;
         exit( EXIT_FAILURE ); 
@@ -325,7 +325,7 @@ const rapidjson::Document SLArBaseGenerator::ExportDirectionConfig() const {
   rapidjson::Value jmode; 
 
   if (dconfig.mode == EDirectionMode::kFixedDir) {
-    len = sprintf(buffer, "fixed"); 
+    len = snprintf(buffer, sizeof(buffer), "fixed"); 
     jmode.SetString(buffer, len, doc.GetAllocator()); 
     doc.AddMember("mode", jmode, doc.GetAllocator()); 
     rapidjson::Value jaxis(rapidjson::kArrayType); 
@@ -335,12 +335,12 @@ const rapidjson::Document SLArBaseGenerator::ExportDirectionConfig() const {
     doc.AddMember("axis", jaxis, doc.GetAllocator()); 
   }
   else if (dconfig.mode == EDirectionMode::kRandomDir) {
-    len = sprintf(buffer, "isotropic"); 
+    len = snprintf(buffer, sizeof(buffer), "isotropic"); 
     jmode.SetString(buffer, len, doc.GetAllocator()); 
     doc.AddMember("mode", jmode, doc.GetAllocator()); 
   }
   else if (dconfig.mode == EDirectionMode::kSunDir) {
-    len = sprintf(buffer, "sun_direction"); 
+    len = snprintf(buffer, sizeof(buffer), "sun_direction"); 
     jmode.SetString(buffer, len, doc.GetAllocator()); 
     doc.AddMember("mode", jmode, doc.GetAllocator()); 
 
@@ -475,19 +475,19 @@ const rapidjson::Document SLArBaseGenerator::ExportEnergyConfig() const {
   rapidjson::Value jmode; 
 
   if (econfig.mode == EEnergyMode::kFixed) {
-    len = sprintf(buffer, "fixed"); 
+    len = snprintf(buffer, sizeof(buffer), "fixed"); 
     jmode.SetString(buffer, len, doc.GetAllocator()); 
     doc.AddMember("mode", jmode, doc.GetAllocator()); 
     doc.AddMember("energy_MeV", econfig.energy_value, doc.GetAllocator()); 
   }
   else if (econfig.mode == EEnergyMode::kCustom) {
-    len = sprintf(buffer, "custom"); 
+    len = snprintf(buffer, sizeof(buffer), "custom"); 
     jmode.SetString(buffer, len, doc.GetAllocator()); 
     doc.AddMember("mode", jmode, doc.GetAllocator()); 
     doc.AddMember("label", rapidjson::StringRef(econfig.energy_distribution_label.data()), doc.GetAllocator()); 
   }
   else if (econfig.mode == EEnergyMode::kExtSpectrum) {
-    len = sprintf(buffer, "spectrum"); 
+    len = snprintf(buffer, sizeof(buffer), "spectrum"); 
     jmode.SetString(buffer, len, doc.GetAllocator()); 
     doc.AddMember("mode", jmode, doc.GetAllocator()); 
     const rapidjson::Document spectrum_doc = ExportEnergyConfig(); 

--- a/G4SOLAr/src/SLArBoxSurfaceVertexGenerator.cc
+++ b/G4SOLAr/src/SLArBoxSurfaceVertexGenerator.cc
@@ -235,7 +235,8 @@ if ( config.HasMember("time") ) {
   auto volume = G4PhysicalVolumeStore::GetInstance()->GetVolume(volumeName); 
   if (volume == nullptr) {
     char err_msg[200]; 
-    sprintf(err_msg, "SLArBoxSurfaceVertexGenerator::Config ERROR\nUnable to find %s in physical volume store.\n", volumeName.data());
+    snprintf(err_msg, sizeof(err_msg),
+	    "SLArBoxSurfaceVertexGenerator::Config ERROR\nUnable to find %s in physical volume store.\n", volumeName.data());
     throw std::runtime_error(err_msg);
   }
 
@@ -263,7 +264,8 @@ void SLArBoxSurfaceVertexGenerator::Config( const G4String& config ) {
   auto volume = G4PhysicalVolumeStore::GetInstance()->GetVolume(volumeName); 
   if (volume == nullptr) {
     char err_msg[200];
-    sprintf(err_msg, "SLArBoxSurfaceVertexGenerator::Config ERROR\nUnable to find %s in physical volume store.\n", volumeName.data());
+    snprintf(err_msg, sizeof(err_msg),
+	     "SLArBoxSurfaceVertexGenerator::Config ERROR\nUnable to find %s in physical volume store.\n", volumeName.data());
     throw std::runtime_error(err_msg); 
   }
 
@@ -296,19 +298,19 @@ const rapidjson::Document SLArBoxSurfaceVertexGenerator::ExportConfig() const {
 
   rapidjson::Value str_gen_type;
   char buffer[50];
-  int len = sprintf(buffer, "%s", gen_type.data());
+  int len = snprintf(buffer, sizeof(buffer),"%s", gen_type.data());
   str_gen_type.SetString(buffer, len, vtx_info.GetAllocator());
   vtx_info.AddMember("type", str_gen_type, vtx_info.GetAllocator()); 
   memset(buffer, 0, sizeof(buffer));
 
   rapidjson::Value str_solid_vol;
-  len = sprintf(buffer, "%s", solid_name.data());
+  len = snprintf(buffer, sizeof(buffer), "%s", solid_name.data());
   str_solid_vol.SetString(buffer, len, vtx_info.GetAllocator());
   vtx_info.AddMember("solid_volume", str_solid_vol, vtx_info.GetAllocator()); 
   memset(buffer, 0, sizeof(buffer));
 
   rapidjson::Value str_logic_vol; 
-  len = sprintf(buffer, "%s", logic_name.data());
+  len = snprintf(buffer, sizeof(buffer), "%s", logic_name.data());
   str_logic_vol.SetString(buffer, len, vtx_info.GetAllocator());
   memset(buffer, 0, sizeof(buffer));
   vtx_info.AddMember("logical_volume", str_logic_vol, vtx_info.GetAllocator()); 

--- a/G4SOLAr/src/SLArBulkVertexGenerator.cc
+++ b/G4SOLAr/src/SLArBulkVertexGenerator.cc
@@ -193,7 +193,8 @@ void SLArBulkVertexGenerator::Config(const G4String& volumeName) {
   auto volume = G4PhysicalVolumeStore::GetInstance()->GetVolume(volumeName); 
   if (volume == nullptr) {
     char err_msg[200]; 
-    sprintf(err_msg, "SLArBulkVertexGenerator::Config Error.\nUnable to find %s in physical volume store.\n", volumeName.c_str());
+    snprintf(err_msg, sizeof(err_msg),
+	    "SLArBulkVertexGenerator::Config Error.\nUnable to find %s in physical volume store.\n", volumeName.c_str());
     throw std::runtime_error(err_msg);
   }
 
@@ -235,19 +236,19 @@ const rapidjson::Document SLArBulkVertexGenerator::ExportConfig() const {
 
   rapidjson::Value str_gen_type;
   char buffer[50];
-  int len = sprintf(buffer, "%s", gen_type.data());
+  int len = snprintf(buffer, sizeof(buffer), "%s", gen_type.data());
   str_gen_type.SetString(buffer, len, vtx_info.GetAllocator());
   vtx_info.AddMember("type", str_gen_type, vtx_info.GetAllocator()); 
   memset(buffer, 0, sizeof(buffer));
 
   rapidjson::Value str_solid_vol;
-  len = sprintf(buffer, "%s", solid_name.data());
+  len = snprintf(buffer, sizeof(buffer), "%s", solid_name.data());
   str_solid_vol.SetString(buffer, len, vtx_info.GetAllocator());
   vtx_info.AddMember("solid_volume", str_solid_vol, vtx_info.GetAllocator()); 
   memset(buffer, 0, sizeof(buffer));
 
   rapidjson::Value str_logic_vol; 
-  len = sprintf(buffer, "%s", logic_name.data());
+  len = snprintf(buffer, sizeof(buffer), "%s", logic_name.data());
   str_logic_vol.SetString(buffer, len, vtx_info.GetAllocator());
   memset(buffer, 0, sizeof(buffer));
   vtx_info.AddMember("logical_volume", str_logic_vol, vtx_info.GetAllocator()); 

--- a/G4SOLAr/src/SLArPrimaryGeneratorAction.cc
+++ b/G4SOLAr/src/SLArPrimaryGeneratorAction.cc
@@ -243,7 +243,7 @@ void SLArPrimaryGeneratorAction::AddGenerator(const rapidjson::Value& jgen) {
       {
         gen::printGeneratorType(); 
         char err_msg[200]; 
-        sprintf(err_msg, "Unable to find %s primary gen among available options.\n", 
+        snprintf(err_msg, sizeof(err_msg), "Unable to find %s primary gen among available options.\n", 
             type.data()); 
         throw std::invalid_argument(err_msg); 
       }

--- a/G4SOLAr/src/config/SLArCfgAnode.cc
+++ b/G4SOLAr/src/config/SLArCfgAnode.cc
@@ -205,6 +205,7 @@ TH2Poly* SLArCfgAnode::ConstructPixHistMap(const int depth,
   }
 
   char err_msg[100]; 
-  sprintf(err_msg, "SLArCfgAnode::ConstructPixHistMap(): ERROR while building anode map with depth level %i\n", depth);
+  snprintf(err_msg, sizeof(err_msg),
+	  "SLArCfgAnode::ConstructPixHistMap(): ERROR while building anode map with depth level %i\n", depth);
   throw std::runtime_error(err_msg); 
 }

--- a/G4SOLAr/src/config/SLArCfgBaseSystem.cc
+++ b/G4SOLAr/src/config/SLArCfgBaseSystem.cc
@@ -77,7 +77,7 @@ TAssemblyModule& SLArCfgBaseSystem<TAssemblyModule>::GetBaseElement(const char* 
   }
   
   char err_msg[100]; 
-  sprintf(err_msg, 
+  snprintf(err_msg, sizeof(err_msg), 
       "SLArCfgBaseSystem::GetBaseElement() ERROR: Element '%s' not found in register\n\n", 
       name);
   throw std::runtime_error(err_msg); 
@@ -160,7 +160,8 @@ TAssemblyModule& SLArCfgBaseSystem<TAssemblyModule>::FindBaseElementInMap(int ib
   }
 
   char err_msg[100]; 
-  sprintf(err_msg, "SLArCfgBaseSystem::FindBaseElementInMap() ERROR: Element with bin index %i not found in register\n\n", ibin);
+  snprintf(err_msg, sizeof(err_msg),
+	  "SLArCfgBaseSystem::FindBaseElementInMap() ERROR: Element with bin index %i not found in register\n\n", ibin);
   throw std::runtime_error(err_msg); 
 }
 

--- a/G4SOLAr/src/cry/SLArCRYGeneratorAction.cc
+++ b/G4SOLAr/src/cry/SLArCRYGeneratorAction.cc
@@ -146,7 +146,7 @@ void SLArCRYGeneratorAction::GeneratePrimaries(G4Event* anEvent)
 void SLArCRYGeneratorAction::CRYConfig_t::activate_particle(const G4String particle_name) {
   if (activeParticles.find( particle_name ) == activeParticles.end()) {
     char err_msg[100]; 
-    sprintf(err_msg, "WARNING: %s is not among cry available primaries\n", 
+    snprintf(err_msg, sizeof(err_msg), "WARNING: %s is not among cry available primaries\n", 
         particle_name.data());
     std::cerr << err_msg << std::endl;
     return;
@@ -162,7 +162,7 @@ void SLArCRYGeneratorAction::CRYConfig_t::to_input() {
     G4String particle = p.first; 
     particle[0] = std::toupper(particle[0]); 
     char line[50]; 
-    sprintf(line, "return%s %i ", particle.data(), p.second);
+    snprintf(line, sizeof(line), "return%s %i ", particle.data(), p.second);
     cry_mess_input.append(line);
   }
   cry_mess_input.append(" "); 

--- a/G4SOLAr/src/radsrc/SLArRadSrcGeneratorAction.cc
+++ b/G4SOLAr/src/radsrc/SLArRadSrcGeneratorAction.cc
@@ -111,7 +111,7 @@ void SLArRadSrcGeneratorAction::RadSrcConfig_t::to_input() {
 
   for (const auto& p : isotopes) {
     char line[50]; 
-    sprintf(line, "%s %g\n", p.first.data(), p.second);
+    snprintf(line, sizeof(line), "%s %g\n", p.first.data(), p.second);
     radsrc_mess_input.append(line);
   }
   radsrc_mess_input.append("\n"); 


### PR DESCRIPTION
We noticed before there were lots of compile warnings, though it turns out these were all the same issue. This was to do with the use of `sprintf` instead of `snprintf`. The former is now deprecated due to the security issues associated with it (lack of control of the buffer size). Whilst this is not a problem for us, the compile warnings were frustrating. 

I believe this function should be available in all the compiler defaults, so shouldn't introduce any problems - I just thought I'd try and fix the compile warnings (of which there are none now on my system). 